### PR TITLE
jshintrc  ignore mocha defined globals

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,4 @@
-// This style is based on the airbnb preset
+// This style is based on the AirBNB preset
 {
 	"excludeFiles": ["node_modules"],
 	"esnext": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-	// best practices
+	// Best practices
 	"freeze": true, // don't screw with protoypes
 	"latedef": "nofunc", // allow use of functions before they're defined, but nothing else
 	"nonbsp": true, // no weird non-breaking space characters
@@ -9,7 +9,7 @@
 	"expr": true, // be friendly to the "should" library
 	"futurehostile": true, // warn about unused reserved words
 
-	// code complexity
+	// Code complexity
 	"maxcomplexity": 10, // max cyclomatic complexity (number of independent paths in a function)
 	"maxdepth": 4, // max number of nested blocks
 	"maxparams": 5, // max number of acceptable function parameters

--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ If you'd like to fail a build when static analysis fails, add a task to your CI 
 
 **[⬆ back to top](#table-of-contents)**
 
-
 ## Strings
 
   - Prefer single quotes `''` for strings. If the string contains single quotes but no double quotes, surround with double quotes `""`.

--- a/pre-commit
+++ b/pre-commit
@@ -1,2 +1,3 @@
 # Add to your .git/hooks file to run lint & style checks before commit code
 npm run analyze
+


### PR DESCRIPTION
I'd like to propose an addition to this repository regarding our .jshintrc file. I believe that we should also use jshint to keep our test suites looking clean. Unfortuately I was running into issues because mocha automagically defines some globals which jshint believes don't exist.

By adding a .jshintrc file(like the one below) to our /test directories we can sidestep the 'global'/'not-defined' problem and have clean looking tests :)

https://github.com/MakerStudios/bazaar-node-sdk/blob/DASH-3706/test/.jshintrc