### PR TITLE
add editor config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 4
+
+# Matches the exact package.json, *.scss, or *.yml
+[{package.json,*.yml,*.scss}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Added an `.editorconfig` file based on the rules in this repo, see [editorconfig.org](http://editorconfig.org/).

> EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.